### PR TITLE
Make the share button optional

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -36,7 +36,9 @@
         <%- post.content %>
       </div>
       <footer class="article-footer">
-        <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" class="article-share-link"><%=__('article.share')%></a>
+        <% if (post.share){ %>
+          <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" class="article-share-link"><%=__('article.share')%></a>
+        <% } %>
         <% if (post.comments && config.disqus_shortname){ %>
           <a href="<%- post.permalink %>#comments" class="article-comment-link"><%=__('article.comments')%></a>
         <% } %>


### PR DESCRIPTION
Now, the share button is included on the page only if the variable
'share' is set to 'true' in the front matter.